### PR TITLE
rdpsnd: restore old behavior and fixes

### DIFF
--- a/channels/rdpsnd/client/alsa/rdpsnd_alsa.c
+++ b/channels/rdpsnd/client/alsa/rdpsnd_alsa.c
@@ -670,10 +670,13 @@ WIN32ERROR freerdp_rdpsnd_client_subsystem_entry(PFREERDP_RDPSND_DEVICE_ENTRY_PO
 	alsa->device.Free = rdpsnd_alsa_free;
 
 	args = pEntryPoints->args;
-	if ((error = rdpsnd_alsa_parse_addin_args((rdpsndDevicePlugin*) alsa, args)))
+	if (args->argc > 1)
 	{
-		WLog_ERR(TAG, "rdpsnd_alsa_parse_addin_args failed with error %lu", error);
-		goto error_parse_args;
+		if ((error = rdpsnd_alsa_parse_addin_args((rdpsndDevicePlugin *) alsa, args)))
+		{
+			WLog_ERR(TAG, "rdpsnd_alsa_parse_addin_args failed with error %lu", error);
+			goto error_parse_args;
+		}
 	}
 
 

--- a/channels/rdpsnd/client/pulse/rdpsnd_pulse.c
+++ b/channels/rdpsnd/client/pulse/rdpsnd_pulse.c
@@ -654,11 +654,14 @@ WIN32ERROR freerdp_rdpsnd_client_subsystem_entry(PFREERDP_RDPSND_DEVICE_ENTRY_PO
 	pulse->device.Free = rdpsnd_pulse_free;
 
 	args = pEntryPoints->args;
-	ret = rdpsnd_pulse_parse_addin_args((rdpsndDevicePlugin*) pulse, args);
-	if (ret != CHANNEL_RC_OK)
+	if (args->argc > 1)
 	{
-		WLog_ERR(TAG, "error parsing arguments");
-		goto error;
+		ret = rdpsnd_pulse_parse_addin_args((rdpsndDevicePlugin *) pulse, args);
+		if (ret != CHANNEL_RC_OK)
+		{
+			WLog_ERR(TAG, "error parsing arguments");
+			goto error;
+		}
 	}
 
 	ret = CHANNEL_RC_NO_MEMORY;

--- a/channels/tsmf/client/oss/tsmf_oss.c
+++ b/channels/tsmf/client/oss/tsmf_oss.c
@@ -211,8 +211,9 @@ static UINT64 tsmf_oss_get_latency(ITSMFAudioDevice* audio)
 	return latency;
 }
 
-static void tsmf_oss_flush(ITSMFAudioDevice* audio)
+static BOOL tsmf_oss_flush(ITSMFAudioDevice* audio)
 {
+	return TRUE;
 }
 
 static void tsmf_oss_free(ITSMFAudioDevice* audio)


### PR DESCRIPTION
* oss: fix function signature
* autodetection - if only /sound is given all enabled
  plugins are tried in order and the first successful loaded is used.
	- this restores the previous behavior
* alsa/pulse fix command line parsing - no parameters shouldn't be
  treated as error